### PR TITLE
#153 카테고리 삭제시 발생하는 에러 해결

### DIFF
--- a/src/main/java/com/example/scrap/entity/Category.java
+++ b/src/main/java/com/example/scrap/entity/Category.java
@@ -38,11 +38,19 @@ public class Category extends BaseEntity implements Comparable<Category>{
     @OneToMany(mappedBy = "category")
     private List<Scrap> scrapList = new ArrayList<>();
 
+    /**
+     * @param sequence 1 이상
+     * @throws IllegalArgumentException sequence가 0 이하의 숫자일 시
+     */
     @Builder
     public Category(String title, int sequence, Member member, Boolean isDefault) {
         this.title = title;
-        this.sequence = sequence;
         this.isDefault = isDefault == null ? false : isDefault;
+
+        if(sequence <= 0){
+            throw new IllegalArgumentException("sequence는 1 이상의 숫자여야 함");
+        }
+        this.sequence = sequence;
 
         setMember(member);
     }

--- a/src/main/java/com/example/scrap/web/category/CategoryCommandServiceImpl.java
+++ b/src/main/java/com/example/scrap/web/category/CategoryCommandServiceImpl.java
@@ -80,19 +80,19 @@ public class CategoryCommandServiceImpl implements ICategoryCommandService {
             throw new BaseException(ErrorCode.NOT_ALLOW_ACCESS_DEFAULT_CATEGORY);
         }
 
-        // [TODO] 리스트를 복제해서 for 문을 돌리는것 외에 다른 방법은 없는지 고민해봐야 될 것 같음. 이렇게 복제된 리스트를 사용하지 않으면, 요소 삭제로 인해 for 문을 다 돌지 못하고 끝나버림.
-        // 모든 스크랩은 기본 카테고리로 이동
-        Category defaultCategory = categoryQueryService.findDefaultCategory(member);
-        List<Scrap> scrapListCopy = new ArrayList<>(category.getScrapList());
-        for(Scrap scrap : scrapListCopy){
-            scrap.moveCategory(defaultCategory);
-        }
-
         // 스크랩을 삭제하기로 결정한 경우
         if(allowDeleteScrap){
             for(Scrap scrap : category.getScrapList()){
                 scrap.toTrash();
             }
+        }
+
+        // [TODO] 리스트를 복제해서 for 문을 돌리는것 외에 다른 방법은 없는지 고민해봐야 될 것 같음. 이렇게 복제된 리스트를 사용하지 않으면, 요소 삭제로 인해 for 문을 다 돌지 못하고 끝나버림.
+        // 모든 스크랩은 기본 카테고리로 이동
+        Category defaultCategory = categoryQueryService.findDefaultCategory(member);
+        List<Scrap> scrapCopyList = new ArrayList<>(category.getScrapList());
+        for(Scrap scrap : scrapCopyList){
+            scrap.moveCategory(defaultCategory);
         }
 
         categoryRepository.delete(category);

--- a/src/main/java/com/example/scrap/web/category/CategoryQueryServiceImpl.java
+++ b/src/main/java/com/example/scrap/web/category/CategoryQueryServiceImpl.java
@@ -41,7 +41,7 @@ public class CategoryQueryServiceImpl implements ICategoryQueryService {
      */
     public Category findDefaultCategory(Member member){
         return categoryRepository.findByMemberAndIsDefaultTrue(member)
-                .orElseThrow(() -> new BaseException(ErrorCode.CATEGORY_NOT_FOUND));
+                .orElseThrow(() -> new BaseException(ErrorCode.DEFAULT_CATEGORY_NOT_FOUND));
     }
 
     /**


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 코드 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
- #153

## 📌 개요
- 삭제하려는 카테고리에 속한 스크랩을 모두 기본 카테고리로 이동한 후
- 삭제하려는 카테고리의 스크랩을 조회하려니 당연히 스크랩 개수가 0일수밖에 없음.

## 👀 기타 더 이야기해볼 점
- 카테고리와 스크랩 삭제시 soft delete로 처리할지, hard delete로 처리할지 고민이 필요해보임.

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
- [x] 담당자를 할당했어요.
- [ ] 리뷰어를 할당했어요.
