### PR TITLE
FIX: 카테고리 삭제시 발생하는 에러 고침

### DIFF
--- a/src/main/java/com/example/scrap/web/category/CategoryCommandServiceImpl.java
+++ b/src/main/java/com/example/scrap/web/category/CategoryCommandServiceImpl.java
@@ -80,19 +80,19 @@ public class CategoryCommandServiceImpl implements ICategoryCommandService {
             throw new BaseException(ErrorCode.NOT_ALLOW_ACCESS_DEFAULT_CATEGORY);
         }
 
-        // [TODO] 리스트를 복제해서 for 문을 돌리는것 외에 다른 방법은 없는지 고민해봐야 될 것 같음. 이렇게 복제된 리스트를 사용하지 않으면, 요소 삭제로 인해 for 문을 다 돌지 못하고 끝나버림.
-        // 모든 스크랩은 기본 카테고리로 이동
-        Category defaultCategory = categoryQueryService.findDefaultCategory(member);
-        List<Scrap> scrapListCopy = new ArrayList<>(category.getScrapList());
-        for(Scrap scrap : scrapListCopy){
-            scrap.moveCategory(defaultCategory);
-        }
-
         // 스크랩을 삭제하기로 결정한 경우
         if(allowDeleteScrap){
             for(Scrap scrap : category.getScrapList()){
                 scrap.toTrash();
             }
+        }
+
+        // [TODO] 리스트를 복제해서 for 문을 돌리는것 외에 다른 방법은 없는지 고민해봐야 될 것 같음. 이렇게 복제된 리스트를 사용하지 않으면, 요소 삭제로 인해 for 문을 다 돌지 못하고 끝나버림.
+        // 모든 스크랩은 기본 카테고리로 이동
+        Category defaultCategory = categoryQueryService.findDefaultCategory(member);
+        List<Scrap> scrapCopyList = new ArrayList<>(category.getScrapList());
+        for(Scrap scrap : scrapCopyList){
+            scrap.moveCategory(defaultCategory);
         }
 
         categoryRepository.delete(category);


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 코드 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
- #153 

## 📌 개요
- 모든 스크랩을 기본 카테고리로 옮기고 나니, 삭제하려는 카테고리에는 아무런 스크랩도 없어져서 발생하는 문제였음.
- 임시방편으로 '스크랩 삭제'를 먼저 실행하게 해서 문제 해결

## 👀 기타 더 이야기해볼 점
- 삭제된 카테고리와 스크랩을 어떻게 다룰지에 대한 고민이 더 필요해 보임.

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
- [x] 담당자를 할당했어요.
- [ ] 리뷰어를 할당했어요.
