### PR TITLE
#162 Category와 Scrap 엔티티 삭제 방식 변경

### DIFF
--- a/src/main/java/com/example/scrap/base/code/ErrorCode.java
+++ b/src/main/java/com/example/scrap/base/code/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode implements BaseCode{
     CATEGORY_MEMBER_NOT_MATCH_IN_SCRAP(HttpStatus.BAD_REQUEST, "CATEGORY005", "해당 스크랩에 접근할 수 없습니다."),
     DEFAULT_CATEGORY_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "CATEGORY006", "기본 카테고리가 존재하지 않습니다."),
     EXCEED_CATEGORY_CREATE_LIMIT(HttpStatus.BAD_REQUEST, "CATEGORY007", "카테고리 최대 생성 개수를 초과했습니다."),
+    DELETED_CATEGORY(HttpStatus.BAD_REQUEST, "CATEGORY008", "해당 카테고리에 접근할 수 없습니다."),
 
     // Scrap Error
     SCRAP_NOT_FOUND(HttpStatus.NOT_FOUND, "SCRAP001", "해당하는 스크랩이 존재하지 않습니다."),

--- a/src/main/java/com/example/scrap/entity/Category.java
+++ b/src/main/java/com/example/scrap/entity/Category.java
@@ -3,6 +3,7 @@ package com.example.scrap.entity;
 import com.example.scrap.base.code.ErrorCode;
 import com.example.scrap.base.exception.BaseException;
 import com.example.scrap.entity.base.BaseEntity;
+import com.example.scrap.entity.enums.CategoryStatus;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,6 +11,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,6 +33,13 @@ public class Category extends BaseEntity implements Comparable<Category>{
     @ColumnDefault("false")
     private Boolean isDefault;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("ACTIVE")
+    private CategoryStatus status;
+
+    private LocalDateTime deletedAt;
+
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "member_id")
     private Member member;
@@ -46,6 +55,7 @@ public class Category extends BaseEntity implements Comparable<Category>{
     public Category(String title, int sequence, Member member, Boolean isDefault) {
         this.title = title;
         this.isDefault = isDefault == null ? false : isDefault;
+        this.status = CategoryStatus.ACTIVE;
 
         if(sequence <= 0){
             throw new IllegalArgumentException("sequence는 1 이상의 숫자여야 함");
@@ -97,4 +107,11 @@ public class Category extends BaseEntity implements Comparable<Category>{
         this.sequence = sequence;
     }
 
+    /**
+     * 카테고리 삭제하기
+     */
+    public void delete(){
+        this.status = CategoryStatus.DELETED;
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/example/scrap/entity/Member.java
+++ b/src/main/java/com/example/scrap/entity/Member.java
@@ -44,6 +44,11 @@ public class Member extends BaseEntity {
         this.memberLog = memberLog;
     }
 
+    // 삭제된 카테고리도 포함하고 있기 때문에, 함부러 접근할 수 없도록 막음
+    protected List<Category> getCategoryList(){
+        return this.categoryList;
+    }
+
     /**
      * 로그인
      */

--- a/src/main/java/com/example/scrap/entity/MemberLog.java
+++ b/src/main/java/com/example/scrap/entity/MemberLog.java
@@ -34,6 +34,7 @@ public class MemberLog extends BaseEntity {
     public MemberLog() {
         this.loginAt = LocalDateTime.now();
         this.loginStatus = LoginStatus.ACTIVE;
+        this.refreshTokenId = 0L;
     }
 
     /**

--- a/src/main/java/com/example/scrap/entity/Scrap.java
+++ b/src/main/java/com/example/scrap/entity/Scrap.java
@@ -37,11 +37,11 @@ public class Scrap extends BaseEntity {
     @ColumnDefault("false")
     private Boolean isFavorite;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")
     private Category category;
 

--- a/src/main/java/com/example/scrap/entity/Scrap.java
+++ b/src/main/java/com/example/scrap/entity/Scrap.java
@@ -3,7 +3,6 @@ package com.example.scrap.entity;
 import com.example.scrap.base.code.ErrorCode;
 import com.example.scrap.base.exception.BaseException;
 import com.example.scrap.entity.base.BaseEntity;
-import com.example.scrap.entity.enums.ScrapStatus;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +10,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -39,13 +37,6 @@ public class Scrap extends BaseEntity {
     @ColumnDefault("false")
     private Boolean isFavorite;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    @ColumnDefault("'ACTIVE'")
-    private ScrapStatus status;
-
-    private LocalDateTime trashedAt;
-
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "member_id")
     private Member member;
@@ -55,14 +46,13 @@ public class Scrap extends BaseEntity {
     private Category category;
 
     @Builder
-    public Scrap(String scrapURL, String title, String imageURL, String description, String memo, Boolean isFavorite, ScrapStatus status, Member member, Category category) {
+    public Scrap(String scrapURL, String title, String imageURL, String description, String memo, Boolean isFavorite, Member member, Category category) {
         this.scrapURL = scrapURL;
         this.title = title;
         this.imageURL = imageURL;
         this.description = description;
         this.memo = memo;
         this.isFavorite = isFavorite == null ? false : isFavorite;
-        this.status = status == null ? ScrapStatus.ACTIVE : status;
         setMember(member);
         setCategory(category);
     }
@@ -123,19 +113,12 @@ public class Scrap extends BaseEntity {
     }
 
     /**
-     * 스크랩 유효성 확인
-     * @return if status is ACTIVE return true, else return false.
-     */
-    public boolean isAvailable(){
-        return status == ScrapStatus.ACTIVE;
-    }
-
-    /**
      * 스크랩 휴지통 보내기
      */
-    public void toTrash(){
-        this.status = ScrapStatus.TRASH;
-        trashedAt = LocalDateTime.now();
+    public TrashScrap toTrash(){
+        category.getScrapList().remove(this);
+
+        return new TrashScrap(this);
     }
 
     /**

--- a/src/main/java/com/example/scrap/entity/TrashScrap.java
+++ b/src/main/java/com/example/scrap/entity/TrashScrap.java
@@ -1,0 +1,71 @@
+package com.example.scrap.entity;
+
+import com.example.scrap.entity.base.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.springframework.data.annotation.CreatedDate;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TrashScrap extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /* Scrap 데이터 시작 */
+    @Column(name = "scrap_url", length = 500, nullable = false)
+    private String scrapURL;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(name = "image_url", length = 500)
+    private String imageURL;
+
+    private String description;
+
+    @Lob
+    private String memo;
+
+    @Column(nullable = false)
+    @ColumnDefault("false")
+    private Boolean isFavorite;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "category_id")
+    private Category category;
+    /* Scrap 데이터 끝 */
+
+    @CreatedDate
+    private LocalDateTime trashedAt;
+
+    public TrashScrap(Scrap scrap){
+        this.scrapURL = scrap.getScrapURL();
+        this.title = scrap.getTitle();
+        this.imageURL = scrap.getImageURL();
+        this.description = scrap.getDescription();
+        this.memo = scrap.getMemo();
+        this.isFavorite = scrap.getIsFavorite();
+        setMember(scrap.getMember());
+        setCategory(scrap.getCategory());
+    }
+
+    private void setMember(Member member){
+        this.member = member;
+    }
+
+    private void setCategory(Category category){
+        this.category = category;
+    }
+}

--- a/src/main/java/com/example/scrap/entity/enums/CategoryStatus.java
+++ b/src/main/java/com/example/scrap/entity/enums/CategoryStatus.java
@@ -1,0 +1,5 @@
+package com.example.scrap.entity.enums;
+
+public enum CategoryStatus {
+    ACTIVE, DELETED
+}

--- a/src/main/java/com/example/scrap/entity/enums/ScrapStatus.java
+++ b/src/main/java/com/example/scrap/entity/enums/ScrapStatus.java
@@ -1,5 +1,0 @@
-package com.example.scrap.entity.enums;
-
-public enum ScrapStatus {
-    ACTIVE, TRASH
-}

--- a/src/main/java/com/example/scrap/specification/ScrapSpecification.java
+++ b/src/main/java/com/example/scrap/specification/ScrapSpecification.java
@@ -3,7 +3,6 @@ package com.example.scrap.specification;
 import com.example.scrap.entity.Category;
 import com.example.scrap.entity.Member;
 import com.example.scrap.entity.Scrap;
-import com.example.scrap.entity.enums.ScrapStatus;
 import com.example.scrap.base.enums.SearchScopeType;
 import org.springframework.data.jpa.domain.Specification;
 
@@ -35,10 +34,6 @@ public class ScrapSpecification {
         return (root, query, criteriaBuilder) -> criteriaBuilder.like(root.get("title"), "%" + title + "%");
     }
 
-    public static Specification<Scrap> isAvailable(){
-        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("status"), ScrapStatus.ACTIVE);
-    }
-
     public static Specification<Scrap> isFavorite(){
         return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("isFavorite"), true);
     }
@@ -46,6 +41,11 @@ public class ScrapSpecification {
     public static Specification<Scrap> inCategory(List<Long> categoryIdList) {
 
         return (root, query, criteriaBuilder) -> criteriaBuilder.and(root.get("category").in(categoryIdList));
+    }
+
+    public static Specification<Scrap> inScrap(List<Long> scrapIdList) {
+
+        return (root, query, criteriaBuilder) -> criteriaBuilder.and(root.get("id").in(scrapIdList));
     }
 
     public static Specification<Scrap> containingQueryInSearchType(String q, SearchScopeType searchScope){

--- a/src/main/java/com/example/scrap/validation/validator/ExistAvailableScrapValidator.java
+++ b/src/main/java/com/example/scrap/validation/validator/ExistAvailableScrapValidator.java
@@ -27,7 +27,7 @@ public class ExistAvailableScrapValidator implements ConstraintValidator<ExistAv
 
         // 스크랩 유효성 확인
         Optional<Scrap> scrap = scrapRepository.findById(value);
-        if(scrap.isEmpty() || !scrap.get().isAvailable()){
+        if(scrap.isEmpty()){
             return false;
         }
 

--- a/src/main/java/com/example/scrap/validation/validator/ExistAvailableScrapsValidator.java
+++ b/src/main/java/com/example/scrap/validation/validator/ExistAvailableScrapsValidator.java
@@ -33,7 +33,7 @@ public class ExistAvailableScrapsValidator implements ConstraintValidator<ExistA
 
             // 스크랩 유효성 확인
             Optional<Scrap> scrap = scrapRepository.findById(scrapId);
-            if(scrap.isEmpty() || !scrap.get().isAvailable()){
+            if(scrap.isEmpty()){
                 return false;
             }
         }

--- a/src/main/java/com/example/scrap/web/category/CategoryCommandServiceImpl.java
+++ b/src/main/java/com/example/scrap/web/category/CategoryCommandServiceImpl.java
@@ -7,7 +7,7 @@ import com.example.scrap.converter.CategoryConverter;
 import com.example.scrap.entity.Category;
 import com.example.scrap.entity.Member;
 import com.example.scrap.entity.Scrap;
-import com.example.scrap.base.data.DefaultData;
+import com.example.scrap.entity.enums.CategoryStatus;
 import com.example.scrap.web.category.dto.CategoryRequest;
 import com.example.scrap.web.member.IMemberQueryService;
 import com.example.scrap.web.member.dto.MemberDTO;
@@ -39,13 +39,16 @@ public class CategoryCommandServiceImpl implements ICategoryCommandService {
         Member member = memberService.findMember(memberDTO);
 
         // 카테고리 생성 개수 제한 확인
-        boolean isExceedCategoryLimit = member.getCategoryList().size() >= PolicyData.CATEGORY_CREATE_LIMIT;
+        long numOfCategory = categoryRepository.countByMemberAndStatus(member, CategoryStatus.ACTIVE);
+        boolean isExceedCategoryLimit = numOfCategory >= PolicyData.CATEGORY_CREATE_LIMIT;
         if(isExceedCategoryLimit){
             throw new BaseException(ErrorCode.EXCEED_CATEGORY_CREATE_LIMIT);
         }
 
-        int newCategorySequence = categoryRepository.findMaxSequenceByMember(member)
-                .orElseThrow(() -> new NoSuchElementException("카테고리의 max sequence를 찾을 수 없음")) + 1;
+        int newCategorySequence = categoryRepository
+                .findMaxSequenceByMemberAndStatus(member, CategoryStatus.ACTIVE)
+                .orElseThrow(() -> new NoSuchElementException("카테고리의 max sequence를 찾을 수 없음"))
+                + 1;
 
         Category newCategory = CategoryConverter.toEntity(member, request, newCategorySequence);
 
@@ -56,8 +59,6 @@ public class CategoryCommandServiceImpl implements ICategoryCommandService {
 
     /**
      * 기본 카테고리 생성
-     * @param member
-     * @return
      */
     public Category createDefaultCategory(Member member){
 
@@ -70,8 +71,8 @@ public class CategoryCommandServiceImpl implements ICategoryCommandService {
 
     /**
      * 카테고리 삭제
-     * @param memberDTO
-     * @param categoryId 카테고리 식별자
+     * @throws BaseException 기본 카테고리를 삭제하려 했을 경우
+     * @throws BaseException 카테고리의 멤버와 요청멤버가 일치하지 않을 경우
      */
     public void deleteCategory(MemberDTO memberDTO, Long categoryId){
         Member member = memberService.findMember(memberDTO);
@@ -90,13 +91,13 @@ public class CategoryCommandServiceImpl implements ICategoryCommandService {
             scrapCommandService.throwScrapIntoTrash(scrap);
         }
 
-        categoryRepository.delete(category);
+        category.delete();
     }
 
     /**
      * 모든 카테고리 삭제하기
      */
-    public void deleteAllCategory(MemberDTO memberDTO){
+    public void deleteAllCategory(MemberDTO memberDTO){ // TODO: 메소드명에 hardDelete 붙이기. memberDTO -> member로 변경하기
         Member member = memberService.findMember(memberDTO);
 
         categoryRepository.deleteAllByMember(member);
@@ -104,10 +105,8 @@ public class CategoryCommandServiceImpl implements ICategoryCommandService {
 
     /** 
      * 카테고리명 수정
-     * @param memberDTO
-     * @param categoryId 카테고리 식별자
-     * @param request
-     * @return 수정된 카테고리
+     * @throws BaseException 기본 카테고리명을 수정하려 했을 경우
+     * @throws BaseException 카테고리의 멤버와 요청멤버가 일치하지 않을 경우
      */
     public Category updateCategoryTitle(MemberDTO memberDTO, Long categoryId, CategoryRequest.UpdateCategoryTitleDTO request){
         Member member = memberService.findMember(memberDTO);
@@ -128,16 +127,21 @@ public class CategoryCommandServiceImpl implements ICategoryCommandService {
 
     /**
      * 카테고리 순서 변경
+     * @throws BaseException 모든 카테고리에 대해 요청을 보내지 않은 경우
+     * @throws BaseException 해당하는 카테고리를 찾을 수 없는 경우
      * @return 새로운 순서로 정렬된 카테고리 목록
      */
     public List<Category> updateCategorySequence(MemberDTO memberDTO, CategoryRequest.UpdateCategorySequenceDTO request){
         Member member = memberService.findMember(memberDTO);
+        List<Category> categoryList = categoryRepository.findAllByMemberAndStatus(member, CategoryStatus.ACTIVE);
 
-        if(request.getCategoryList().size() != member.getCategoryList().size()){
+        // 모든 카테고리에 대해 요청했는지 확인
+        boolean isRequestCategoryNotAll = request.getCategoryList().size() != categoryList.size();
+        if(isRequestCategoryNotAll){
             throw new BaseException(ErrorCode.REQUEST_CATEGORY_COUNT_NOT_ALL);
         }
 
-        // 정렬된 카테고리 id에 sequence 순서대로 부여
+        // 순서가 변경된 카테고리 id에 차례대로 sequence 순서대로 부여
         Map<Long, Integer> changeSequenceMap = new HashMap<>();
         int newSequence = 1;
         for(Long categoryId : request.getCategoryList()){
@@ -146,12 +150,16 @@ public class CategoryCommandServiceImpl implements ICategoryCommandService {
         }
 
         // 순서 변경
-        for(Category category : member.getCategoryList()){
+        for(Category category : categoryList){
+            if(!changeSequenceMap.containsKey(category.getId())){ // 요청한 카테고리를 못찾은 경우
+                throw new BaseException(ErrorCode.CATEGORY_NOT_FOUND);
+            }
+
             category.changeSequence(changeSequenceMap.get(category.getId()));
         }
 
-        Collections.sort(member.getCategoryList());
-        return member.getCategoryList();
+        Collections.sort(categoryList);
+        return categoryList;
     }
 
 }

--- a/src/main/java/com/example/scrap/web/category/CategoryController.java
+++ b/src/main/java/com/example/scrap/web/category/CategoryController.java
@@ -79,15 +79,13 @@ public class CategoryController {
     /**
      * [DELETE] /categories/{category-id}?allow_delete_category=
      * [API-9] 카테고리 삭제
-     * @param allowDeleteScrap 해당 카테고리에 속한 스크랩 삭제 여부
      */
     @DeleteMapping("/{category-id}")
-    public ResponseEntity<ResponseDTO> categoryRemove(@RequestHeader("Authorization") String token, @PathVariable("category-id") @ExistCategory Long categoryId,
-                                      @RequestParam("allow_delete_scrap") Boolean allowDeleteScrap){
+    public ResponseEntity<ResponseDTO> categoryRemove(@RequestHeader("Authorization") String token, @PathVariable("category-id") @ExistCategory Long categoryId){
 
         MemberDTO memberDTO = tokenProvider.parseAccessToMemberDTO(token);
 
-        categoryCommandService.deleteCategory(memberDTO, categoryId, allowDeleteScrap);
+        categoryCommandService.deleteCategory(memberDTO, categoryId);
 
         return ResponseEntity.ok(new ResponseDTO());
     }

--- a/src/main/java/com/example/scrap/web/category/CategoryQueryServiceImpl.java
+++ b/src/main/java/com/example/scrap/web/category/CategoryQueryServiceImpl.java
@@ -4,6 +4,7 @@ import com.example.scrap.base.code.ErrorCode;
 import com.example.scrap.base.exception.BaseException;
 import com.example.scrap.entity.Category;
 import com.example.scrap.entity.Member;
+import com.example.scrap.entity.enums.CategoryStatus;
 import com.example.scrap.web.member.IMemberQueryService;
 import com.example.scrap.web.member.dto.MemberDTO;
 import lombok.RequiredArgsConstructor;
@@ -25,31 +26,24 @@ public class CategoryQueryServiceImpl implements ICategoryQueryService {
 
     /**
      * 카테고리 전체 조회
-     * @param memberDTO
-     * @return 전체 카테고리
      */
     public List<Category> getCategoryWholeList(MemberDTO memberDTO){
         Member member = memberService.findMember(memberDTO);
 
-        return categoryRepository.findAllByMemberOrderBySequence(member);
-    }
-
-    /**
-     * 기본 카테고리 찾기
-     * @param member
-     * @return
-     */
-    public Category findDefaultCategory(Member member){
-        return categoryRepository.findByMemberAndIsDefaultTrue(member)
-                .orElseThrow(() -> new BaseException(ErrorCode.DEFAULT_CATEGORY_NOT_FOUND));
+        return categoryRepository.findAllByMemberAndStatusOrderBySequence(member, CategoryStatus.ACTIVE);
     }
 
     /**
      * 카테고리 찾기
-     * @param categoryId
-     * @return
+     * @throws BaseException 삭제된 카테고리인 경우
      */
     public Category findCategory(Long categoryId){
-        return categoryRepository.findById(categoryId).get();
+        Category category = categoryRepository.findById(categoryId).get();
+
+        if(category.getStatus().equals(CategoryStatus.DELETED)){
+            throw new BaseException(ErrorCode.DELETED_CATEGORY);
+        }
+
+        return category;
     }
 }

--- a/src/main/java/com/example/scrap/web/category/CategoryRepository.java
+++ b/src/main/java/com/example/scrap/web/category/CategoryRepository.java
@@ -2,6 +2,7 @@ package com.example.scrap.web.category;
 
 import com.example.scrap.entity.Category;
 import com.example.scrap.entity.Member;
+import com.example.scrap.entity.enums.CategoryStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -12,12 +13,10 @@ import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
-    public List<Category> findAllByMemberOrderBySequence(Member member);
-
     /**
-     * 기본 카테고리 찾기
+     * 순서에 맞게 카테고리 조회
      */
-    public Optional<Category> findByMemberAndIsDefaultTrue(Member member);
+    public List<Category> findAllByMemberAndStatusOrderBySequence(Member member, CategoryStatus status);
 
     @Modifying
     @Query("DELETE FROM Category c WHERE c.member =:member")
@@ -26,8 +25,17 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     /**
      * 가장 높은 sequence를 가진 카테고리 찾기
      */
-    @Query("SELECT MAX(c.sequence) FROM Category c WHERE c.member =:member")
-    public Optional<Integer> findMaxSequenceByMember(@Param("member") Member member);
+    @Query("SELECT MAX(c.sequence) FROM Category c WHERE c.member =:member and c.status =:status")
+    public Optional<Integer> findMaxSequenceByMemberAndStatus(@Param("member") Member member, @Param("status") CategoryStatus status);
 
-    public long countByMember(Member member);
+
+    /**
+     * 총 카테고리 개수 조회
+     */
+    public int countByMemberAndStatus(Member member, CategoryStatus status);
+
+    /**
+     * 모든 카테고리 조회
+     */
+    public List<Category> findAllByMemberAndStatus(Member member, CategoryStatus status);
 }

--- a/src/main/java/com/example/scrap/web/category/ICategoryCommandService.java
+++ b/src/main/java/com/example/scrap/web/category/ICategoryCommandService.java
@@ -22,7 +22,7 @@ public interface ICategoryCommandService {
     /**
      * 카테고리 삭제
      */
-    public void deleteCategory(MemberDTO memberDTO, Long categoryId, Boolean allowDeleteScrap);
+    public void deleteCategory(MemberDTO memberDTO, Long categoryId);
 
     /**
      * 모든 카테고리 삭제하기

--- a/src/main/java/com/example/scrap/web/category/ICategoryQueryService.java
+++ b/src/main/java/com/example/scrap/web/category/ICategoryQueryService.java
@@ -1,7 +1,6 @@
 package com.example.scrap.web.category;
 
 import com.example.scrap.entity.Category;
-import com.example.scrap.entity.Member;
 import com.example.scrap.web.member.dto.MemberDTO;
 
 import java.util.List;
@@ -14,10 +13,6 @@ public interface ICategoryQueryService {
      */
     public List<Category> getCategoryWholeList(MemberDTO memberDTO);
 
-    /**
-     * 기본 카테고리 찾기
-     */
-    Category findDefaultCategory(Member member);
 
     public Category findCategory(Long categoryId);
 }

--- a/src/main/java/com/example/scrap/web/mypage/MypageQueryServiceImpl.java
+++ b/src/main/java/com/example/scrap/web/mypage/MypageQueryServiceImpl.java
@@ -32,9 +32,7 @@ public class MypageQueryServiceImpl implements IMypageQueryService {
         long totalCategory = categoryRepository.countByMember(member);
 
         // 총 스크랩 개수
-        Specification<Scrap> spec = Specification.where(ScrapSpecification.isAvailable())
-                .and(ScrapSpecification.equalMember(member));
-        long totalScrap = scrapRepository.count(spec);
+        long totalScrap = scrapRepository.countAllByMember(member);
 
         return MypageDTO.builder()
                 .name(member.getName())

--- a/src/main/java/com/example/scrap/web/mypage/MypageQueryServiceImpl.java
+++ b/src/main/java/com/example/scrap/web/mypage/MypageQueryServiceImpl.java
@@ -1,15 +1,13 @@
 package com.example.scrap.web.mypage;
 
 import com.example.scrap.entity.Member;
-import com.example.scrap.entity.Scrap;
-import com.example.scrap.specification.ScrapSpecification;
+import com.example.scrap.entity.enums.CategoryStatus;
 import com.example.scrap.web.category.CategoryRepository;
 import com.example.scrap.web.member.IMemberQueryService;
 import com.example.scrap.web.member.dto.MemberDTO;
 import com.example.scrap.web.mypage.dto.MypageResponse.*;
 import com.example.scrap.web.scrap.ScrapRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,7 +27,7 @@ public class MypageQueryServiceImpl implements IMypageQueryService {
         Member member = memberQueryService.findMember(memberDTO);
 
         // 총 카테고리 개수
-        long totalCategory = categoryRepository.countByMember(member);
+        long totalCategory = categoryRepository.countByMemberAndStatus(member, CategoryStatus.ACTIVE);
 
         // 총 스크랩 개수
         long totalScrap = scrapRepository.countAllByMember(member);

--- a/src/main/java/com/example/scrap/web/scrap/IScrapCommandService.java
+++ b/src/main/java/com/example/scrap/web/scrap/IScrapCommandService.java
@@ -2,6 +2,7 @@ package com.example.scrap.web.scrap;
 
 import com.example.scrap.entity.Scrap;
 import com.example.scrap.base.enums.QueryRange;
+import com.example.scrap.entity.TrashScrap;
 import com.example.scrap.web.member.dto.MemberDTO;
 import com.example.scrap.web.scrap.dto.ScrapRequest;
 
@@ -44,14 +45,19 @@ public interface IScrapCommandService {
     public Scrap updateScrapMemo(MemberDTO memberDTO, Long scrapId, ScrapRequest.UpdateScrapMemoDTO request);
 
     /**
-     * 스크랩 삭제(단건)
+     * 스크랩 휴지통에 버리기(단건)
      */
-    public void throwScrapInTrash(MemberDTO memberDTO, Long scrapId);
+    public TrashScrap throwScrapIntoTrash(MemberDTO memberDTO, Long scrapId);
 
     /**
-     * 스크랩 삭제(목록)
+     * 스크랩 휴지통에 버리기(목록)
      */
-    public void throwScrapListInTrash(MemberDTO memberDTO, boolean isAllDelete, QueryRange queryRange, Long categoryId, ScrapRequest.DeleteScrapListDTO request);
+    public List<TrashScrap> throwScrapListIntoTrash(MemberDTO memberDTO, boolean isAllDelete, QueryRange queryRange, Long categoryId, ScrapRequest.DeleteScrapListDTO request);
+
+    /**
+     * 스크랩 휴지통에 버리기
+     */
+    public TrashScrap throwScrapIntoTrash(Scrap scrap);
 
     /**
      * 스크랩 전체 삭제

--- a/src/main/java/com/example/scrap/web/scrap/IScrapQueryService.java
+++ b/src/main/java/com/example/scrap/web/scrap/IScrapQueryService.java
@@ -43,14 +43,4 @@ public interface IScrapQueryService {
      * 스크랩 찾기
      */
     public Scrap findScrap(Long scrapId);
-
-    /**
-     * 프레스 타입에 따른 스크랩 조회
-     */
-    List<Scrap> findAllByQueryRange(Member member, QueryRange queryRange, Long categoryId);
-
-    /**
-     * 요청된 스크랩 조회
-     */
-    public List<Scrap> findAllByRequest(List<Long> scrapIdList, Member member);
 }

--- a/src/main/java/com/example/scrap/web/scrap/ScrapCommandServiceImpl.java
+++ b/src/main/java/com/example/scrap/web/scrap/ScrapCommandServiceImpl.java
@@ -8,6 +8,7 @@ import com.example.scrap.entity.Category;
 import com.example.scrap.entity.Member;
 import com.example.scrap.entity.Scrap;
 import com.example.scrap.base.enums.QueryRange;
+import com.example.scrap.entity.TrashScrap;
 import com.example.scrap.specification.ScrapSpecification;
 import com.example.scrap.web.category.ICategoryQueryService;
 import com.example.scrap.web.member.IMemberQueryService;
@@ -16,9 +17,11 @@ import com.example.scrap.web.scrap.dto.ScrapRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 
@@ -28,14 +31,15 @@ import java.util.List;
 @Slf4j
 public class ScrapCommandServiceImpl implements IScrapCommandService {
 
-    private final IMemberQueryService memberService;
+    private final IMemberQueryService memberService; // TODO: 변수명 변경하기
     private final ICategoryQueryService categoryService;
-    private final ScrapRepository scrapRepository;
     private final IScrapQueryService scrapQueryService;
+    private final ScrapRepository scrapRepository;
+    private final TrashScrapRepository trashScrapRepository;
 
     /**
      * 스크랩 생성하기
-     * @throws BaseException 카테고리와 멤버가 일치하지 않을 경우
+     * @throws BaseException 카테고리의 멤버와 요청멤버가 일치하지 않을 경우
      * @throws BaseException 스크랩 생성 개수를 초과할 경우
      */
     public Scrap createScrap(MemberDTO memberDTO, Long categoryId, ScrapRequest.CreateScrapDTO request){
@@ -45,9 +49,7 @@ public class ScrapCommandServiceImpl implements IScrapCommandService {
         category.checkIllegalMember(member);
 
         // 스크랩 생성 개수 제한 확인
-        Specification<Scrap> spec = Specification.where(ScrapSpecification.isAvailable())
-                .and(ScrapSpecification.equalMember(member));
-        boolean isExceedScrapLimit = scrapRepository.count(spec) >= PolicyData.SCRAP_CREATE_LIMIT;
+        boolean isExceedScrapLimit = scrapRepository.countAllByMember(member) >= PolicyData.SCRAP_CREATE_LIMIT;
         if(isExceedScrapLimit){
             throw new BaseException(ErrorCode.EXCEED_SCRAP_CREATE_LIMIT);
         }
@@ -61,7 +63,7 @@ public class ScrapCommandServiceImpl implements IScrapCommandService {
 
     /**
      * 스크랩 즐겨찾기(단건)
-     * @throws BaseException 스크랩과 멤버가 일치하지 않을 경우
+     * @throws BaseException 스크랩의 멤버와 요청멤버가 일치하지 않을 경우
      */
     public Scrap toggleScrapFavorite(MemberDTO memberDTO, Long scrapId){
         Member member = memberService.findMember(memberDTO);
@@ -76,48 +78,60 @@ public class ScrapCommandServiceImpl implements IScrapCommandService {
 
     /**
      * 스크랩 즐겨찾기(목록)
+     *
+     * 즐겨찾기 해제인지, 즐겨찾기인지 알아내기
+     * ★ ☆ ★ ☆ = 즐겨찾기 O
+     * ☆ ☆ ☆ ☆ = 즐겨찾기 O
+     * ★ ★ ★ ★ = 즐겨찾기 X
+     *
+     * @throws BaseException 카테고리의 멤버와 요청멤버가 일치하지 않을 경우
      */
     public List<Scrap> toggleScrapFavoriteList(MemberDTO memberDTO,
                                                boolean isAllFavorite, QueryRange queryRange, Long categoryId,
                                                ScrapRequest.ToggleScrapFavoriteListDTO request){
 
         Member member = memberService.findMember(memberDTO);
-        List<Scrap> favoriteScrapList;
 
-        // 전체 즐겨찾기
-        if(isAllFavorite){
-            favoriteScrapList = scrapQueryService.findAllByQueryRange(member, queryRange, categoryId);
+        // 동적인 쿼리 생성
+        Specification<Scrap> spec = Specification.where(ScrapSpecification.equalMember(member));
+        if(isAllFavorite){ // 전체 즐겨찾기 하기
+            Category category = null;
+
+            if(queryRange.equals(QueryRange.CATEGORY)){
+                category = categoryService.findCategory(categoryId);
+                category.checkIllegalMember(member);
+            }
+
+            spec = addQueryRangeSpec(spec, queryRange, category);
         }
-        // 요청된 스크랩만 즐겨찾기
-        else{
-            favoriteScrapList = scrapQueryService.findAllByRequest(request.getScrapIdList(), member);
+        else{ // 요청된 스크랩에 대해서만 즐겨찾기 하기
+            spec = spec.and(ScrapSpecification.inScrap(request.getScrapIdList()));
         }
 
-        /**
-         * 즐겨찾기 해제인지, 즐겨찾기인지 알아내기
-         * ★ ☆ ★ ☆ = 즐겨찾기 O
-         * ☆ ☆ ☆ ☆ = 즐겨찾기 O
-         * ★ ★ ★ ★ = 즐겨찾기 X
-         */
+
+        List<Scrap> scrapList = scrapRepository.findAll(spec);
+
+        // 즐겨찾기 O/X 여부 판별하기
         boolean toggle = false;
-        for(Scrap scrap : favoriteScrapList){
+        for(Scrap scrap : scrapList){
             if(!scrap.getIsFavorite()){
                 toggle = true; // 선택된 스크랩중 하나라도 즐겨찾기X인게 있으면, 해당 스크랩 목록 전체 즐겨찾기하기.
                 break;
             }
         }
 
-        for(Scrap scrap : favoriteScrapList){
+        // 스크랩 즐겨찾기 설정하기
+        for(Scrap scrap : scrapList){
             scrap.updateFavorite(toggle);
         }
 
-        return favoriteScrapList;
+        return scrapList;
     }
 
     /**
      * 스크랩 이동하기 (단건)
-     * @throws BaseException 카테고리와 멤버가 일치하지 않을 경우
-     * @throws BaseException 스크랩과 멤버가 일치하지 않을 경우
+     * @throws BaseException 카테고리의 멤버와 요청멤버가 일치하지 않을 경우
+     * @throws BaseException 스크랩의 멤버와 요청멤버가 일치하지 않을 경우
      */
     public Scrap moveCategoryOfScrap(MemberDTO memberDTO, Long scrapId, ScrapRequest.MoveCategoryOfScrapDTO request){
         Member member = memberService.findMember(memberDTO);
@@ -139,40 +153,42 @@ public class ScrapCommandServiceImpl implements IScrapCommandService {
 
     /**
      * 스크랩 이동하기 (목록)
-     * @throws BaseException 이동하려는 카테고리와 멤버가 일치하지 않을 경우
+     * @throws BaseException 카테고리의 멤버와 요청멤버가 일치하지 않을 경우
      */
     public List<Scrap> moveCategoryOfScraps(MemberDTO memberDTO, ScrapRequest.MoveCategoryOfScrapsDTO request,
                                             boolean isAllMove, QueryRange queryRange, Long categoryId){
 
         Member member = memberService.findMember(memberDTO);
         Category moveCategory = categoryService.findCategory(request.getMoveCategoryId());
-        List<Scrap> moveScrapList;
 
-        // 해당 스크랩에 접근할 수 있는지 확인
-        // TODO: checkIlligalMember로 변경하기
-        if(moveCategory.isIllegalMember(member)){
-            throw new BaseException(ErrorCode.CATEGORY_MEMBER_NOT_MATCH_IN_SCRAP);
+        // TODO: moveCategory member 체크하기
+
+        // 동적인 쿼리 생성
+        Specification<Scrap> spec = Specification.where(ScrapSpecification.equalMember(member));
+        if(isAllMove){ // 전체 스크랩 이동하기
+            Category category = null;
+
+            if(queryRange.equals(QueryRange.CATEGORY)){
+                category = categoryService.findCategory(categoryId);
+                category.checkIllegalMember(member);
+            }
+            spec = addQueryRangeSpec(spec, queryRange, category);
+        }
+        else{ // 요청된 스크랩에 대해서만 이동하기
+            spec = spec.and(ScrapSpecification.inScrap(request.getScrapIdList()));
         }
 
-        // 전체 이동하기
-        if(isAllMove){
-            moveScrapList = scrapQueryService.findAllByQueryRange(member, queryRange, categoryId);
-        }
-        // 요청된 스크랩만 이동하기
-        else{
-            moveScrapList = scrapQueryService.findAllByRequest(request.getScrapIdList(), member);
-        }
-
-        for(Scrap scrap : moveScrapList){
+        List<Scrap> scrapList = scrapRepository.findAll(spec);
+        for(Scrap scrap : scrapList){
             scrap.moveCategory(moveCategory);
         }
 
-        return moveScrapList;
+        return scrapList;
     }
 
     /**
      * 스크랩의 메모 수정
-     * @throws BaseException 스크랩과 멤버가 일치하지 않을 경우
+     * @throws BaseException 스크랩의 멤버와 요청멤버가 일치하지 않을 경우
      */
     public Scrap updateScrapMemo(MemberDTO memberDTO, Long scrapId, ScrapRequest.UpdateScrapMemoDTO request){
         Member member = memberService.findMember(memberDTO);
@@ -186,37 +202,62 @@ public class ScrapCommandServiceImpl implements IScrapCommandService {
     }
 
     /**
-     * 스크랩 삭제(단건)
-     * @throws BaseException 스크랩과 멤버가 일치하지 않을 경우
+     * 스크랩 휴지통에 버리기(단건)
+     * @throws BaseException 스크랩의 멤버와 요청멤버가 일치하지 않을 경우
      */
-    public void throwScrapInTrash(MemberDTO memberDTO, Long scrapId){
+    public TrashScrap throwScrapIntoTrash(MemberDTO memberDTO, Long scrapId){
         Member member = memberService.findMember(memberDTO);
         Scrap scrap = scrapQueryService.findScrap(scrapId);
 
         scrap.checkIllegalMember(member);
 
-        scrap.toTrash();
+        return throwScrapIntoTrash(scrap);
     }
 
     /**
-     * 스크랩 삭제(목록)
+     * 스크랩 휴지통에 버리기(목록)
+     * @throws BaseException 카테고리의 멤버와 요청멤버가 일치하지 않을 경우
      */
-    public void throwScrapListInTrash(MemberDTO memberDTO, boolean isAllDelete, QueryRange queryRange, Long categoryId, ScrapRequest.DeleteScrapListDTO request){
+    public List<TrashScrap> throwScrapListIntoTrash(MemberDTO memberDTO, boolean isAllDelete, QueryRange queryRange, Long categoryId, ScrapRequest.DeleteScrapListDTO request){
         Member member = memberService.findMember(memberDTO);
-        List<Scrap> deleteScrapList;
 
-        // 모든 스크랩 삭제
-        if(isAllDelete){
-            deleteScrapList = scrapQueryService.findAllByQueryRange(member, queryRange, categoryId);
+        // 동적인 쿼리 생성
+        Specification<Scrap> spec = Specification.where(ScrapSpecification.equalMember(member));
+        if(isAllDelete){ // 전체 휴지통에 버리기
+            Category category = null;
+
+            if(queryRange.equals(QueryRange.CATEGORY)){
+                category = categoryService.findCategory(categoryId);
+                category.checkIllegalMember(member);
+            }
+
+            spec = addQueryRangeSpec(spec, queryRange, category);
         }
-        // 요청된 스크랩만 삭제
-        else{
-            deleteScrapList = scrapQueryService.findAllByRequest(request.getScrapIdList(), member);
+        else{ // 요청된 스크랩에 대해서만 휴지통에 버리기
+            spec = spec.and(ScrapSpecification.inScrap(request.getScrapIdList()));
         }
 
-        for(Scrap scrap : deleteScrapList){
-            scrap.toTrash();
+        List<Scrap> scrapList = scrapRepository.findAll(spec);
+
+        // 스크랩 휴지통에 버리기
+        List<TrashScrap> trashScrapList = new ArrayList<>();
+        for(Scrap scrap : scrapList){
+            trashScrapList.add(throwScrapIntoTrash(scrap));
         }
+
+        return trashScrapList;
+    }
+
+    /**
+     * 휴지통에 스크랩 버리기
+     */
+    public TrashScrap throwScrapIntoTrash(Scrap scrap){
+        TrashScrap trashScrap = scrap.toTrash();
+
+        scrapRepository.delete(scrap); // 스크랩 삭제
+        trashScrapRepository.save(trashScrap); // 휴지통에 스크랩 보관
+
+        return trashScrap;
     }
 
     /**
@@ -226,5 +267,21 @@ public class ScrapCommandServiceImpl implements IScrapCommandService {
         Member member = memberService.findMember(memberDTO);
 
         scrapRepository.deleteAllByMember(member);
+    }
+
+    /**
+     * QueryRange에 따른 Specification 추가
+     */
+    private Specification<Scrap> addQueryRangeSpec(Specification<Scrap> spec, QueryRange queryRange, @Nullable Category category){
+        switch (queryRange){
+            case CATEGORY -> { // 카테고리에서 검색
+                spec = spec.and(ScrapSpecification.equalCategory(category));
+            }
+            case FAVORITE -> { // 즐겨찾기에서 검색
+                spec = spec.and(ScrapSpecification.isFavorite());
+            }
+        }
+
+        return spec;
     }
 }

--- a/src/main/java/com/example/scrap/web/scrap/ScrapController.java
+++ b/src/main/java/com/example/scrap/web/scrap/ScrapController.java
@@ -283,7 +283,7 @@ public class ScrapController {
 
         MemberDTO memberDTO = tokenProvider.parseAccessToMemberDTO(token);
 
-        scrapCommandService.throwScrapInTrash(memberDTO, scrapId);
+        scrapCommandService.throwScrapIntoTrash(memberDTO, scrapId);
 
         return ResponseEntity.ok(new ResponseDTO<Void>());
     }
@@ -310,7 +310,7 @@ public class ScrapController {
             checkCategoryMissing(categoryId, queryRange);
         }
 
-        scrapCommandService.throwScrapListInTrash(memberDTO, isAllDelete, queryRange, categoryId, request);
+        scrapCommandService.throwScrapListIntoTrash(memberDTO, isAllDelete, queryRange, categoryId, request);
 
         return ResponseEntity.ok(new ResponseDTO<Void>());
     }

--- a/src/main/java/com/example/scrap/web/scrap/ScrapQueryServiceImpl.java
+++ b/src/main/java/com/example/scrap/web/scrap/ScrapQueryServiceImpl.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,11 +44,7 @@ public class ScrapQueryServiceImpl implements IScrapQueryService {
 
         category.checkIllegalMember(member);
 
-        Specification<Scrap> spec = Specification.where(ScrapSpecification.isAvailable())
-                .and(ScrapSpecification.equalMember(member))
-                .and(ScrapSpecification.equalCategory(category));
-
-        return  scrapRepository.findAll(spec, pageRequest);
+        return scrapRepository.findByMemberAndCategory(member, category, pageRequest);
     }
 
     /**
@@ -57,11 +54,7 @@ public class ScrapQueryServiceImpl implements IScrapQueryService {
     public Page<Scrap> getFavoriteScrapList(MemberDTO memberDTO, PageRequest pageRequest){
         Member member = memberQueryService.findMember(memberDTO);
 
-        Specification<Scrap> spec = Specification.where(ScrapSpecification.isAvailable())
-                .and(ScrapSpecification.equalMember(member))
-                .and(ScrapSpecification.isFavorite());
-
-        return scrapRepository.findAll(spec, pageRequest);
+        return scrapRepository.findByMemberAndIsFavoriteIsTrue(member, pageRequest);
     }
 
     /**
@@ -83,11 +76,18 @@ public class ScrapQueryServiceImpl implements IScrapQueryService {
      */
     public List<Scrap> findScrapByTitle(MemberDTO memberDTO, QueryRange queryRange, Long categoryId, String query, Sort sort){
         Member member = memberQueryService.findMember(memberDTO);
+        Category category = null;
 
-        Specification<Scrap> spec = createSpecByQueryRange(member, queryRange, categoryId);
+        // 카테고리를 대상으로 조회가 필요한 경우
+        if(queryRange.equals(QueryRange.CATEGORY)){
+            category = categoryQueryService.findCategory(categoryId);
+            category.checkIllegalMember(member);
+        }
 
-        // 제목으로 검색
-        spec = spec.and(ScrapSpecification.containingTitle(query));
+        // 동적인 쿼리 생성
+        Specification<Scrap> spec = Specification.where(ScrapSpecification.equalMember(member))
+                .and(ScrapSpecification.containingTitle(query)); // 제목 조건
+        spec = addQueryRangeSpec(spec, queryRange, category);
 
         return scrapRepository.findAll(spec, sort);
     }
@@ -96,10 +96,20 @@ public class ScrapQueryServiceImpl implements IScrapQueryService {
      * 스크랩 전체 공유하기
      */
     public List<Scrap> shareAllScrap(MemberDTO memberDTO, QueryRange queryRange, Long categoryId){
-
         Member member = memberQueryService.findMember(memberDTO);
+        Category category = null;
 
-        return findAllByQueryRange(member, queryRange, categoryId);
+        // 카테고리를 대상으로 조회가 필요한 경우
+        if(queryRange.equals(QueryRange.CATEGORY)){
+            category = categoryQueryService.findCategory(categoryId);
+            category.checkIllegalMember(member);
+        }
+
+        // 동적인 쿼리 생성
+        Specification<Scrap> spec = Specification.where(ScrapSpecification.equalMember(member));
+        spec = addQueryRangeSpec(spec, queryRange, category);
+
+        return scrapRepository.findAll(spec);
     }
 
     /**
@@ -110,59 +120,18 @@ public class ScrapQueryServiceImpl implements IScrapQueryService {
     }
 
     /**
-     * 조회 타입에 따른 스크랩 조회
-     * @throws BaseException CATEGORY_MEMBER_NOT_MATCH_IN_SCRAP
+     * QueryRange에 따른 Specification 추가
      */
-    public List<Scrap> findAllByQueryRange(Member member, QueryRange queryRange, Long categoryId){
-        Specification<Scrap> spec = createSpecByQueryRange(member, queryRange, categoryId);
-
-        return scrapRepository.findAll(spec);
-    }
-
-    /**
-     * 조회 타입에 따른 스크랩 Specification 생성
-     * @throws BaseException CATEGORY_MEMBER_NOT_MATCH_IN_SCRAP
-     */
-    public Specification<Scrap> createSpecByQueryRange(Member member, QueryRange queryRange, Long categoryId){
-        Specification<Scrap> spec = Specification.where(ScrapSpecification.isAvailable())
-                .and(ScrapSpecification.equalMember(member));
-
-        // 어떤 프레스 타입인지
+    private Specification<Scrap> addQueryRangeSpec(Specification<Scrap> spec, QueryRange queryRange, @Nullable Category category){
         switch (queryRange){
-            case CATEGORY -> {
-                Category category = categoryQueryService.findCategory(categoryId);
-                // TODO: checkIllegalMember()로 변경하기
-                if(category.isIllegalMember(member)){
-                    throw new BaseException(ErrorCode.CATEGORY_MEMBER_NOT_MATCH_IN_SCRAP);
-                }
+            case CATEGORY -> { // 카테고리에서 검색
                 spec = spec.and(ScrapSpecification.equalCategory(category));
             }
-            case FAVORITE -> {
+            case FAVORITE -> { // 즐겨찾기에서 검색
                 spec = spec.and(ScrapSpecification.isFavorite());
             }
         }
 
         return spec;
-    }
-
-    /**
-     * 요청된 스크랩 조회
-     * @throws IllegalArgumentException if scrapIdList empty
-     */
-    public List<Scrap> findAllByRequest(List<Long> scrapIdList, Member member){
-        List<Scrap> scrapList = new ArrayList<>();
-
-        if(scrapIdList.isEmpty()){
-            throw new IllegalArgumentException("scrapIdList가 비어있습니다.");
-        }
-        for(Long scrapId : scrapIdList){
-            Scrap scrap = findScrap(scrapId);
-
-            scrap.checkIllegalMember(member);
-
-            scrapList.add(scrap);
-        }
-
-        return scrapList;
     }
 }

--- a/src/main/java/com/example/scrap/web/scrap/ScrapRepository.java
+++ b/src/main/java/com/example/scrap/web/scrap/ScrapRepository.java
@@ -1,7 +1,10 @@
 package com.example.scrap.web.scrap;
 
+import com.example.scrap.entity.Category;
 import com.example.scrap.entity.Member;
 import com.example.scrap.entity.Scrap;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
@@ -9,10 +12,17 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+
 @Repository
 public interface ScrapRepository extends JpaRepository<Scrap, Long>, JpaSpecificationExecutor<Scrap>{
 
     @Modifying
     @Query("DELETE FROM Scrap s WHERE s.member =:member")
     public void deleteAllByMember(@Param("member") Member member);
+
+    Page<Scrap> findByMemberAndCategory(Member member, Category category, PageRequest pageRequest);
+
+    Page<Scrap> findByMemberAndIsFavoriteIsTrue(Member member, PageRequest pageRequest);
+
+    int countAllByMember(Member member);
 }

--- a/src/main/java/com/example/scrap/web/scrap/TrashScrapRepository.java
+++ b/src/main/java/com/example/scrap/web/scrap/TrashScrapRepository.java
@@ -1,0 +1,7 @@
+package com.example.scrap.web.scrap;
+
+import com.example.scrap.entity.TrashScrap;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TrashScrapRepository extends JpaRepository<TrashScrap, Long> {
+}

--- a/src/main/java/com/example/scrap/web/search/SearchQueryServiceImpl.java
+++ b/src/main/java/com/example/scrap/web/search/SearchQueryServiceImpl.java
@@ -32,9 +32,7 @@ public class SearchQueryServiceImpl implements ISearchQueryService {
 
         Member member = memberQueryService.findMember(memberDTO);
 
-        Specification<Scrap> spec = Specification.where(ScrapSpecification.isAvailable())
-                .and(ScrapSpecification.equalMember(member));
-
+        Specification<Scrap> spec = Specification.where(ScrapSpecification.equalMember(member));
 
         // 검색범위 지정
         Specification<Scrap> specSearchScope = (root, q, criteriaBuilder) -> null;

--- a/src/test/java/com/example/scrap/mypage/MypageQueryServiceImplTest.java
+++ b/src/test/java/com/example/scrap/mypage/MypageQueryServiceImplTest.java
@@ -2,6 +2,7 @@ package com.example.scrap.mypage;
 
 import com.example.scrap.entity.Member;
 import com.example.scrap.entity.MemberLog;
+import com.example.scrap.entity.enums.CategoryStatus;
 import com.example.scrap.entity.enums.SnsType;
 import com.example.scrap.web.category.CategoryRepository;
 import com.example.scrap.web.member.IMemberQueryService;
@@ -15,12 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.jpa.domain.Specification;
-import org.springframework.test.util.ReflectionTestUtils;
-
-import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -46,8 +42,8 @@ public class MypageQueryServiceImplTest {
         MemberDTO memberDTO = setupMemberDTO(member);
 
         when(memberQueryService.findMember(memberDTO)).thenReturn(member);
-        when(categoryRepository.countByMember(member)).thenReturn(7L);
-        when(scrapRepository.count(isA(Specification.class))).thenReturn(99L);
+        when(categoryRepository.countByMemberAndStatus(member, CategoryStatus.ACTIVE)).thenReturn(7);
+        when(scrapRepository.countAllByMember(member)).thenReturn(99);
 
         //** when
         MypageResponse.MypageDTO mypageDTO = mypageQueryService.mypage(memberDTO);

--- a/src/test/java/com/example/scrap/scrap/ScrapQueryServiceImplTest.java
+++ b/src/test/java/com/example/scrap/scrap/ScrapQueryServiceImplTest.java
@@ -1,15 +1,11 @@
 package com.example.scrap.scrap;
 
 import com.example.scrap.base.code.ErrorCode;
-import com.example.scrap.base.data.DefaultData;
-import com.example.scrap.base.enums.Sorts;
 import com.example.scrap.base.exception.BaseException;
 import com.example.scrap.entity.Category;
 import com.example.scrap.entity.Member;
 import com.example.scrap.entity.Scrap;
-import com.example.scrap.entity.enums.ScrapStatus;
 import com.example.scrap.entity.enums.SnsType;
-import com.example.scrap.specification.ScrapSpecification;
 import com.example.scrap.web.category.ICategoryQueryService;
 import com.example.scrap.web.member.IMemberQueryService;
 import com.example.scrap.web.member.dto.MemberDTO;
@@ -20,10 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.*;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.ArrayList;
@@ -218,7 +211,6 @@ public class ScrapQueryServiceImplTest {
         return Scrap.builder()
                 .member(member)
                 .category(category)
-                .status(ScrapStatus.ACTIVE)
                 .title("스크랩 제목")
                 .scrapURL("https://scrap")
                 .imageURL("https://image")


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 코드 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
- #162 

## 📌 개요
- Category: hard delete -> soft delelte로 변경
  - 이유: 나중에 스크랩을 휴지통에서 복구할 시, 기존에 속해있던 카테고리로 복구하게 하기 위함.
- Scrap: soft delete -> hard delete로 변경. 그리고 휴지통에 버려진 스크랩은 TrashScrap 엔티티로 분리하여 관리
  - 이유: 스크랩은 삭제보단 조회가 훨씬 많이 이뤄질 것이라 예상. 그래서 조회 조건에 status가 계속 붙는게 성능에 좋지 않은 영향을 미칠것이라 판단됨. 거기에 휴지통에 버려진지 30일이 지난 스크랩은 hard delete 예정이기 때문에 매 자정마다 scrap 테이블을 일괄 조회해야 함. 이때를 위해서라도 TrashScrap으로 분리하는게 나아보였음.

## 👀 기타 더 이야기해볼 점
- 바뀐 코드에 대한 실질적인 성능 테스트  해보면 좋을 것 같음

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
- [x] 담당자를 할당했어요.
- [ ] 리뷰어를 할당했어요.
