### PR TITLE
Request Body 필드명 프론트와 서버 통일

### DIFF
--- a/src/main/java/com/example/scrap/web/category/dto/CategoryRequest.java
+++ b/src/main/java/com/example/scrap/web/category/dto/CategoryRequest.java
@@ -1,6 +1,5 @@
 package com.example.scrap.web.category.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -41,7 +40,6 @@ public class CategoryRequest {
     public static class UpdateCategorySequenceDTO{
 
         @NotEmpty
-        @JsonProperty("categories")
-        private List<Long> categoryList;
+        private List<Long> categoryIdList;
     }
 }

--- a/src/main/java/com/example/scrap/web/scrap/dto/ScrapRequest.java
+++ b/src/main/java/com/example/scrap/web/scrap/dto/ScrapRequest.java
@@ -1,6 +1,5 @@
 package com.example.scrap.web.scrap.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -55,7 +54,6 @@ public class ScrapRequest {
     public static class DeleteScrapListDTO {
 
         @NotEmpty
-        @JsonProperty("scraps")
         private List<Long> scrapIdList;
     }
 
@@ -68,7 +66,6 @@ public class ScrapRequest {
     public static class ToggleScrapFavoriteListDTO {
 
         @NotEmpty
-        @JsonProperty("scraps")
         private List<Long> scrapIdList;
     }
 
@@ -80,7 +77,6 @@ public class ScrapRequest {
     @NoArgsConstructor
     public static class MoveCategoryOfScrapDTO {
 
-        @JsonProperty("moveCategory")
         private Long moveCategoryId;
     }
 
@@ -93,11 +89,9 @@ public class ScrapRequest {
     public static class MoveCategoryOfScrapsDTO {
 
         @NotEmpty
-        @JsonProperty("scraps")
         private List<Long> scrapIdList;
 
         @NotNull
-        @JsonProperty("moveCategory")
         private Long moveCategoryId;
     }
 }

--- a/src/main/java/com/example/scrap/web/search/SearchQueryServiceImpl.java
+++ b/src/main/java/com/example/scrap/web/search/SearchQueryServiceImpl.java
@@ -43,8 +43,8 @@ public class SearchQueryServiceImpl implements ISearchQueryService {
         spec = spec.and(specSearchScope);
 
         // 카테고리 범위 지정
-        if(!(request.getCategoryIdList() == null || request.getCategoryIdList().isEmpty())){
-            spec = spec.and(ScrapSpecification.inCategory(request.getCategoryIdList()));
+        if(!(request.getCategoryScope() == null || request.getCategoryScope().isEmpty())){
+            spec = spec.and(ScrapSpecification.inCategory(request.getCategoryScope()));
         }
 
         // 시작 날짜 ~ 종료 날짜 지정

--- a/src/main/java/com/example/scrap/web/search/dto/SearchRequest.java
+++ b/src/main/java/com/example/scrap/web/search/dto/SearchRequest.java
@@ -3,7 +3,6 @@ package com.example.scrap.web.search.dto;
 import com.example.scrap.validation.annotaion.EnumsValid;
 import com.example.scrap.base.data.DefaultData;
 import com.example.scrap.base.enums.SearchScopeType;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,8 +21,7 @@ public class SearchRequest {
         @EnumsValid(enumC = SearchScopeType.class)
         private List<String> searchScope;
 
-        @JsonProperty(value = "categoryScope")
-        private List<Long> categoryIdList;
+        private List<Long> categoryScope;
 
         private LocalDate startDate;
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 코드 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
- #171

## 📌 개요
- 클라이언트측에 보이는 RequestBody의 필드명과 서버측에서 쓰는 RequestBody의 필드명 일치시키기
- @JsonProperty를 사용해 클라이언트측에 보이는 필드명과 서버측에서 쓰는 필드명을 다르게 사용하니 2가지 문제가 발생했음.
  - 컨트롤러에 대한 테스트 코드 작성 불가 (테스트 코드를 작성할 때 Request Body는 서버측을 기준으로 만들수 있으나, 실제로 컨트롤러에 전달되어야 하는건 프론트측이어야해서)
  - 에러메시지의 필드명이 클라이언트측이 쓰던게 아닌 서버측이 쓰던거라 혼란 야기

## 👀 기타 더 이야기해볼 점
-

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
- [x] 담당자를 할당했어요.
- [ ] 리뷰어를 할당했어요.
