### PR TITLE
#187 [API-6] 카테고리 전제 조회시 발생하는 N+1 문제 해결

### DIFF
--- a/src/main/java/com/example/scrap/web/category/CategoryRepository.java
+++ b/src/main/java/com/example/scrap/web/category/CategoryRepository.java
@@ -3,6 +3,7 @@ package com.example.scrap.web.category;
 import com.example.scrap.entity.Category;
 import com.example.scrap.entity.Member;
 import com.example.scrap.entity.enums.CategoryStatus;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -16,6 +17,7 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     /**
      * 순서에 맞게 카테고리 조회
      */
+    @EntityGraph(attributePaths = {"scrapList"})
     public List<Category> findAllByMemberAndStatusOrderBySequence(Member member, CategoryStatus status);
 
     @Modifying


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 코드 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
- #187

## 📌 개요
- N개의 카테고리를 1개의 쿼리문으로 조회하면서, 조회된 카테고리의 개수만큼 스크랩을 조회하는 쿼리문이 날라감.
- @EntityGraph를 통해 해결

## 👀 기타 더 이야기해볼 점
- [API-21] 즐겨찾기된 스크랩 조회와 [API-22] 검색 API의 경우 성능 개선 지점을 조금 더 고민해봐야 될 것 같음.
- 왜냐하면, 두 API같은 경우 조회된 N개의 데이터만큼 추가 쿼리문이 날라가는 것이 아니라, 데이터가 몇개가 조회되든 추가로 날라가는 쿼리문은 1~15개 정도로 일정하기 때문. (스크랩과 연관된 카테고리 개수만큼 추가 쿼리문이 날라감.)
- 나중에 실제 성능이 안좋다고 느끼거나 카테고리 생성 개수에 제한이 없어져 문제가 된다고 판단되면 그때 해결을 해야할 것 같음.

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
- [x] 담당자를 할당했어요.
- [ ] 리뷰어를 할당했어요.
